### PR TITLE
merge-cron-use-theirs

### DIFF
--- a/merge-cron/cron.bat
+++ b/merge-cron/cron.bat
@@ -2,6 +2,6 @@ cd repo/main
 git pull
 cd ../staging-data
 git pull
-git merge main
+git merge main --strategy-option theirs
 git push --set-upstream origin staging-data
 cd ../..

--- a/merge-cron/cron.sh
+++ b/merge-cron/cron.sh
@@ -2,6 +2,6 @@ cd repo/main
 git pull
 cd ../staging-data
 git pull
-git merge main
+git merge main --strategy-option theirs
 git push --set-upstream origin staging-data
 cd ../..


### PR DESCRIPTION
# Problem

When merging, a merge conflict could arise even though we always want to accept incoming merges

# Solution

Added  --strategy-option theirs to the merge so that in the case of a merge conflict, it will always accept incoming merges